### PR TITLE
feature:UMDEV-5612 Allow specification of environment when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,28 @@ Main features:
 - Filter tests using account settings
 - Run tests in parallel across multiple nodes
 - Generate JUnit reports
- 
 ## Installation
- 
-1) Clone this repository from GitHub
 
-2) Build the plugin:
-```
-mvn clean package
-```
-3. Install the plugin:
+1. Clone this repository from GitHub
+
+2. Build the plugin:
+
+    ```
+    mvn clean package
+    ```
+3. Run plugin project in local Jenkins environment:
+   ```
+   mvn hpi:run
+   ```
+    Environment variables to be set (for development/testing)
+     - UM_CLIENT_ID
+     - UM_TEST_APP_URL
+     - UM_TEST_SERVICE_URL
+4. Generate distributable _.hpi_ file:
+    ```
+   mvn hpi:hpi
+   ```
+5. Install the plugin:
     - Copy to your `%JENKINS_HOME%\plugins` directory, **OR**
     - Login to Jenkins and upload your plugin (`Jenkins` -> `Manage Jenkins` -> `Manage Plugins` -> `Advanced`)
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ mvn clean package
     1. Add the build step `Run useMango tests` 
     2. Enter your `Project ID` (i.e. the name of your project in your useMango account)
     3. Add further filtering where needed
+       1. You can select the environment from the dropdown (note: The project's default environment is preselected)
     4. Click the `Validate` button to validate your settings (note: only the tests shown will be executed during the build)
     5. Optional:  Add the post-build action `Publish JUnit test result report` and enter `results/*.xml` as the value for `Test report XMLs`.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ mvn clean package
 
 - Create a new Freestyle project and configure:
     1. Add the build step `Run useMango tests` 
-    2. Enter your `Project ID` (i.e. the name of your project in your useMango account)
+    2. Enter your `Project` (i.e. the name of your project in your useMango account)
     3. Add further filtering where needed
        1. You can select the environment from the dropdown (note: The project's default environment is preselected)
     4. Click the `Validate` button to validate your settings (note: only the tests shown will be executed during the build)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>it.infuse.jenkins</groupId>
     <artifactId>usemango-runner</artifactId>
-    <version>1.13-SNAPSHOT</version>
+    <version>1.13</version>
     <packaging>hpi</packaging>
     <name>useMango Runner</name>
     <description>This plugin integrates useMango with Jenkins.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <description>This plugin integrates useMango with Jenkins.</description>
     <properties>
     	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <licenses>
@@ -149,7 +149,7 @@
     										maven-enforcer-plugin
     									</artifactId>
     									<versionRange>
-    										[3.0.0-M1,)
+    										[3.1.0-M1,)
     									</versionRange>
     									<goals>
     										<goal>display-info</goal>

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
@@ -287,7 +287,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
         @POST
         public FormValidation doCheckProjectId(@QueryParameter String value)
                 throws IOException, ServletException {
-            if (value.length() == 0) return FormValidation.error("Please set a Project ID");
+            if (value.length() == 0) return FormValidation.error("Please set a Project");
 
             List<String> projectTags = new ArrayList<>();
 			try {
@@ -341,7 +341,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
     			return FormValidation.error("Jenkins user '"+User.current()+"' does not have permissions to configure and build this Job - please contact your system administrator, or update the users' security settings.");
     		}
     		else if(StringUtils.isBlank(projectId)) {
-    			return FormValidation.error("Please complete mandatory Project ID field above");
+    			return FormValidation.error("Please complete mandatory Project field above");
     		}
 			else if (StringUtils.isBlank(environmentId)) {
 				return FormValidation.error("Environment is mandatory");

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
@@ -4,6 +4,7 @@ import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.google.api.client.http.HttpResponseException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
@@ -58,10 +59,11 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 	private String testName;
 	private String testStatus;
 	private String assignedTo;
+	private String environmentId;
 
 	@DataBoundConstructor
 	public UseMangoBuilder(String useSlaveNodes, String nodeLabel, String projectId, String tags, String testName,
-			String testStatus, String assignedTo) {
+			String testStatus, String assignedTo, String environmentId) {
 		this.useSlaveNodes = useSlaveNodes;
 		this.nodeLabel = nodeLabel;
 		this.projectId = projectId;
@@ -69,6 +71,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 		this.testName = testName;
 		this.testStatus = testStatus;
 		this.assignedTo = assignedTo;
+		this.environmentId = environmentId;
 	}
 	
 	@SuppressFBWarnings(value="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
@@ -110,27 +113,27 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 			params.setTestStatus(this.testStatus);
 			listener.getLogger().println("TestIndex API parameters:\n"+gson.toJson(params));
 
-			TestIndexResponse indexes = null;
-			indexes = getTestIndexes(params);
+			Response<TestIndexItem> testIndexes = null;
+			testIndexes = getTestIndexes(params);
 
-			if(indexes != null && indexes.getItems() != null && indexes.getItems().size() > 0) {
+			if(testIndexes != null && testIndexes.getItems() != null && testIndexes.getItems().size() > 0) {
 
 				build.getWorkspace().child(ProjectUtils.LOG_DIR).mkdirs();
 				build.getWorkspace().child(ProjectUtils.RESULTS_DIR).mkdirs();
 
-				listener.getLogger().println(indexes.getItems().size() + " tests retrieved:\n"+gson.toJson(indexes.getItems()));
+				listener.getLogger().println(testIndexes.getItems().size() + " tests retrieved:\n"+gson.toJson(testIndexes.getItems()));
 
 				List<String> logList = new ArrayList<>();
 				List<ExecutableTest> executions = new ArrayList<>();
 				BiConsumer<TestIndexItem, Scenario> queueTest = (indexItem, scenario) -> {
 					ExecutableTest exeTest = new ExecutableTest(indexItem, scenario);
-					UseMangoTestTask testTask = new UseMangoTestTask(nodeLabel, build, listener, exeTest, projectId, credentials);
+					UseMangoTestTask testTask = new UseMangoTestTask(nodeLabel, build, listener, exeTest, projectId, environmentId, credentials);
 					executions.add(exeTest);
 					testTasks.add(testTask);
 					Jenkins.getInstance().getQueue().schedule2(testTask, Jenkins.getInstance().getQuietPeriod());
 					logList.add(ProjectUtils.getLogFileName(exeTest));
 				};
-				indexes.getItems().forEach((test) -> {
+				testIndexes.getItems().forEach((test) -> {
 					try {
 						if (test.getHasScenarios()){
 							List<Scenario> scenarios = getTestScenarios(this.projectId, test.getId());
@@ -207,7 +210,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
     			List<Project> projects = getProjects();
     			if(projects != null) {
     				projects.forEach(project->{
-    					items.add(project.getName());
+    					items.add(project.getName(), project.getId());
     				});
     			}
     		}
@@ -234,8 +237,29 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 			}
 			return items;
 		}
-        
-        public ListBoxModel doFillTestStatusItems() {
+         
+		public ListBoxModel doFillEnvironmentIdItems(@QueryParameter String projectId) {
+			ListBoxModel items = new ListBoxModel();
+			try {
+				Response<EnvironmentItem> environments = getEnvironments(projectId);
+				if(environments != null && environments.getItems() != null && !environments.getItems().isEmpty()) {
+					List<EnvironmentItem> environmentItems = environments.getItems();
+					environmentItems.forEach(environmentItem -> {
+						String name = environmentItem.getName();
+						String id = environmentItem.getId();
+						boolean isDefault = environmentItem.isDefault();
+						ListBoxModel.Option option = new ListBoxModel.Option(name, id, isDefault);
+						items.add(option);
+					});
+                }
+			}
+			catch(IOException | UseMangoException e) {
+				e.printStackTrace(System.out);
+			}
+			return items;
+		}
+
+		public ListBoxModel doFillTestStatusItems() {
     		ListBoxModel items = new ListBoxModel();
     		items.add(""); // blank top option
     		items.add("Design");
@@ -290,19 +314,38 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 			}
         }
 
+		@POST
+		public FormValidation doCheckEnvironmentId(@QueryParameter String projectId)
+				throws IOException, UseMangoException {
+			try {
+				if(!projectId.isEmpty()) {
+					String defaultEnvironmentName = getDefaultEnvironment(projectId).getName();
+					return FormValidation.okWithMarkup("Default Environment: " + defaultEnvironmentName);
+				}
+				return FormValidation.ok();
+			}
+			catch (HttpResponseException e) {
+				return FormValidation.warning("Some error occurred");
+			}
+		}
+
     	public FormValidation doValidateSettings(
     			@QueryParameter("projectId") final String projectId,
     			@QueryParameter("tags") final String tags,
     			@QueryParameter("testName") final String testName,
     	        @QueryParameter("testStatus") final String testStatus,
-    	        @QueryParameter("assignedTo") final String assignedTo) throws IOException, ServletException {
-    		
+    	        @QueryParameter("assignedTo") final String assignedTo,
+				@QueryParameter("environmentId") final String environmentId) throws IOException {
+
     		if(!ProjectUtils.hasCorrectPermissions(User.current())) {
     			return FormValidation.error("Jenkins user '"+User.current()+"' does not have permissions to configure and build this Job - please contact your system administrator, or update the users' security settings.");
     		}
     		else if(StringUtils.isBlank(projectId)) {
     			return FormValidation.error("Please complete mandatory Project ID field above");
     		}
+			else if (StringUtils.isBlank(environmentId)) {
+				return FormValidation.error("Environment is mandatory");
+			}
     		else {
 	    		try {
 	    		    List<UmUser> users = getUsers();
@@ -317,7 +360,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 	    			params.setProjectId(projectId);
 	    			params.setTestName(testName);
 	    			params.setTestStatus(testStatus);
-	    			TestIndexResponse indexes = getTestIndexes(params);
+					Response<TestIndexItem> indexes = getTestIndexes(params);
 
 					String umURL = Util.escape(APIUtils.getTestServiceUrl());
 					String userName = Util.escape(credentials.getUsername());
@@ -441,7 +484,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 		}
 	}
 
-	private static TestIndexResponse getTestIndexes(TestIndexParams params) throws IOException, UseMangoException {
+	private static Response<TestIndexItem> getTestIndexes(TestIndexParams params) throws IOException, UseMangoException {
 		checkTokenExistsAndValid();
 		if(params == null) throw new UseMangoException("Test parameters are null, please check useMango build step in job");
 		return APIUtils.getTestIndex(params, ID_TOKEN);
@@ -461,6 +504,16 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 	private static List<String> getProjectTags(String projectId) throws IOException, UseMangoException{
 		checkTokenExistsAndValid();
 		return APIUtils.getProjectTags(ID_TOKEN, projectId);
+	}
+
+	private static EnvironmentItem getDefaultEnvironment(String projectId) throws IOException, UseMangoException{
+		checkTokenExistsAndValid();
+		return APIUtils.getDefaultEnvironment(ID_TOKEN, projectId);
+	}
+
+	private static Response<EnvironmentItem> getEnvironments(String projectId) throws IOException, UseMangoException {
+		checkTokenExistsAndValid();
+		return APIUtils.getEnvironments(ID_TOKEN, projectId);
 	}
 
 	private static List<UmUser> getUsers() throws IOException, UseMangoException {
@@ -512,6 +565,13 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 	 */
 	public String getAssignedTo() {
 		return assignedTo;
+	}
+
+	/**
+	 * @return the environment
+	 */
+	public String getEnvironmentId() {
+		return environmentId;
 	}
 
 	/**

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
@@ -113,7 +113,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 			params.setTestStatus(this.testStatus);
 			listener.getLogger().println("TestIndex API parameters:\n"+gson.toJson(params));
 
-			Response<TestIndexItem> testIndexes = null;
+			TestIndexResponse testIndexes = null;
 			testIndexes = getTestIndexes(params);
 
 			if(testIndexes != null && testIndexes.getItems() != null && testIndexes.getItems().size() > 0) {
@@ -241,7 +241,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 		public ListBoxModel doFillEnvironmentIdItems(@QueryParameter String projectId) {
 			ListBoxModel items = new ListBoxModel();
 			try {
-				Response<EnvironmentItem> environments = getEnvironments(projectId);
+				EnvironmentResponse environments = getEnvironments(projectId);
 				if(environments != null && environments.getItems() != null && !environments.getItems().isEmpty()) {
 					List<EnvironmentItem> environmentItems = environments.getItems();
 					environmentItems.forEach(environmentItem -> {
@@ -271,9 +271,9 @@ public class UseMangoBuilder extends Builder implements BuildStep {
     	}
 
         @POST
-        public FormValidation doCheckNodeLabel(@QueryParameter String nodeLabel) 
+        public FormValidation doCheckNodeLabel(@QueryParameter String nodeLabel)
         		throws IOException, ServletException {
-        	
+
         	if(StringUtils.isNotBlank(nodeLabel)) {
         		Label label = Label.get(nodeLabel);
         		if(label != null && label.getNodes() != null && label.getNodes().size() > 0) {
@@ -314,28 +314,28 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 			}
         }
 
-		@POST
-		public FormValidation doCheckEnvironmentId(@QueryParameter String projectId)
-				throws IOException, UseMangoException {
-			try {
-				if(!projectId.isEmpty()) {
-					String defaultEnvironmentName = getDefaultEnvironment(projectId).getName();
-					return FormValidation.okWithMarkup("Default Environment: " + defaultEnvironmentName);
-				}
-				return FormValidation.ok();
-			}
-			catch (HttpResponseException e) {
-				return FormValidation.warning("Some error occurred");
-			}
-		}
+        @POST
+        public FormValidation doCheckEnvironmentId(@QueryParameter String projectId)
+                throws IOException, UseMangoException {
+            try {
+        		if(!projectId.isEmpty()) {
+        			String defaultEnvironmentName = getDefaultEnvironment(projectId).getName();
+        			return FormValidation.okWithMarkup("Default Environment: " + defaultEnvironmentName);
+        		}
+        		return FormValidation.ok();
+        	}
+        	catch (HttpResponseException e) {
+        		return FormValidation.warning("Error fetching project's default environment:" + e.getMessage());
+        	}
+        }
 
     	public FormValidation doValidateSettings(
     			@QueryParameter("projectId") final String projectId,
     			@QueryParameter("tags") final String tags,
     			@QueryParameter("testName") final String testName,
-    	        @QueryParameter("testStatus") final String testStatus,
-    	        @QueryParameter("assignedTo") final String assignedTo,
-				@QueryParameter("environmentId") final String environmentId) throws IOException {
+    			@QueryParameter("testStatus") final String testStatus,
+    			@QueryParameter("assignedTo") final String assignedTo,
+    			@QueryParameter("environmentId") final String environmentId) throws IOException {
 
     		if(!ProjectUtils.hasCorrectPermissions(User.current())) {
     			return FormValidation.error("Jenkins user '"+User.current()+"' does not have permissions to configure and build this Job - please contact your system administrator, or update the users' security settings.");
@@ -360,7 +360,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 	    			params.setProjectId(projectId);
 	    			params.setTestName(testName);
 	    			params.setTestStatus(testStatus);
-					Response<TestIndexItem> indexes = getTestIndexes(params);
+	    			TestIndexResponse indexes = getTestIndexes(params);
 
 					String umURL = Util.escape(APIUtils.getTestServiceUrl());
 					String userName = Util.escape(credentials.getUsername());
@@ -484,7 +484,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 		}
 	}
 
-	private static Response<TestIndexItem> getTestIndexes(TestIndexParams params) throws IOException, UseMangoException {
+	private static TestIndexResponse getTestIndexes(TestIndexParams params) throws IOException, UseMangoException {
 		checkTokenExistsAndValid();
 		if(params == null) throw new UseMangoException("Test parameters are null, please check useMango build step in job");
 		return APIUtils.getTestIndex(params, ID_TOKEN);
@@ -511,7 +511,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 		return APIUtils.getDefaultEnvironment(ID_TOKEN, projectId);
 	}
 
-	private static Response<EnvironmentItem> getEnvironments(String projectId) throws IOException, UseMangoException {
+	private static EnvironmentResponse getEnvironments(String projectId) throws IOException, UseMangoException {
 		checkTokenExistsAndValid();
 		return APIUtils.getEnvironments(ID_TOKEN, projectId);
 	}

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoTestExecutor.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoTestExecutor.java
@@ -42,7 +42,7 @@ public class UseMangoTestExecutor implements Executable {
         this.listener = listener;
         this.test = test;
         this.projectId = projectId;
-		this.environmentId = environmentId;
+        this.environmentId = environmentId;
         this.credentials = credentials;
     }
 

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoTestExecutor.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoTestExecutor.java
@@ -15,6 +15,7 @@ import hudson.util.ArgumentListBuilder;
 import it.infuse.jenkins.usemango.model.ExecutableTest;
 import it.infuse.jenkins.usemango.model.Scenario;
 import it.infuse.jenkins.usemango.util.ProjectUtils;
+import it.infuse.jenkins.usemango.util.StringUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.ByteArrayOutputStream;
@@ -30,16 +31,18 @@ public class UseMangoTestExecutor implements Executable {
 	private final BuildListener listener;
 	private final ExecutableTest test;
 	private final String projectId;
+	private final String environmentId;
 	private final StandardUsernamePasswordCredentials credentials;
 
     public UseMangoTestExecutor(Task task, FilePath workspace, BuildListener listener,
-			ExecutableTest test, String projectId,
+			ExecutableTest test, String projectId, String environmentId,
             StandardUsernamePasswordCredentials credentials){
     	this.task = task;
     	this.workspace = workspace;
         this.listener = listener;
         this.test = test;
         this.projectId = projectId;
+		this.environmentId = environmentId;
         this.credentials = credentials;
     }
 
@@ -162,6 +165,9 @@ public class UseMangoTestExecutor implements Executable {
     	args.addTokenized(motorPath);
 		args.addTokenized(" -p \""+projectId+"\"");
 		args.addTokenized(" -i \""+test.getId()+"\"");
+		if (!StringUtils.isBlank(environmentId) || environmentId != null) {
+			args.addTokenized(" -v \""+ environmentId +"\"");
+		}
 
 		Scenario scenario = test.getScenario();
 		if (scenario != null) {

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoTestTask.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoTestTask.java
@@ -39,7 +39,7 @@ public class UseMangoTestTask extends AbstractQueueTask implements AccessControl
         this.listener = listener;
         this.test = test;
         this.projectId = projectId;
-		this.environmentId = environmentId;
+        this.environmentId = environmentId;
         this.credentials = credentials;
     }
 

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoTestTask.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoTestTask.java
@@ -28,16 +28,18 @@ public class UseMangoTestTask extends AbstractQueueTask implements AccessControl
 	private final BuildListener listener;
 	private final ExecutableTest test;
 	private final String projectId;
+	private final String environmentId;
 	private final StandardUsernamePasswordCredentials credentials;
 
     public UseMangoTestTask(String nodeLabel, AbstractBuild<?,?> build, BuildListener listener,
-			ExecutableTest test, String projectId,
+			ExecutableTest test, String projectId, String environmentId,
 			StandardUsernamePasswordCredentials credentials) {
 		this.nodeLabel = nodeLabel;
     	this.build = build;
         this.listener = listener;
         this.test = test;
         this.projectId = projectId;
+		this.environmentId = environmentId;
         this.credentials = credentials;
     }
 
@@ -121,6 +123,6 @@ public class UseMangoTestTask extends AbstractQueueTask implements AccessControl
 	
     public Executable createExecutable() throws IOException {
     	return new UseMangoTestExecutor(this, build.getWorkspace(), listener, test,
-										projectId, credentials);
+										projectId, environmentId, credentials);
     }
 }

--- a/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentItem.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentItem.java
@@ -1,0 +1,52 @@
+package it.infuse.jenkins.usemango.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EnvironmentItem extends GenericJson {
+    @Key("Id")
+    private String id;
+    @Key("Name")
+    private String name;
+    @Key("IsDefault")
+    private boolean isDefault;
+
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public void setDefault(boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof EnvironmentItem)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentResponse.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentResponse.java
@@ -2,7 +2,7 @@ package it.infuse.jenkins.usemango.model;
 
 import java.util.List;
 
-public class EnvironmentResponse extends Response<EnvironmentItem> {
+public class EnvironmentResponse extends PagedResponse<EnvironmentItem> {
 
 	public List<EnvironmentItem> getItems() {
 		return super.getItems();

--- a/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentResponse.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/EnvironmentResponse.java
@@ -1,0 +1,11 @@
+package it.infuse.jenkins.usemango.model;
+
+import java.util.List;
+
+public class EnvironmentResponse extends Response<EnvironmentItem> {
+
+	public List<EnvironmentItem> getItems() {
+		return super.getItems();
+	}
+
+}

--- a/src/main/java/it/infuse/jenkins/usemango/model/PagedResponse.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/PagedResponse.java
@@ -5,7 +5,7 @@ import com.google.api.client.util.Key;
 
 import java.util.List;
 
-public class Response<T> extends GenericJson {
+public class PagedResponse<T> extends GenericJson {
     @Key("Items")
     private List<T> items;
     @Key("FullCount")
@@ -45,7 +45,7 @@ public class Response<T> extends GenericJson {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Response)) {
+        if (!(o instanceof PagedResponse)) {
             return false;
         }
         return super.equals(o);

--- a/src/main/java/it/infuse/jenkins/usemango/model/Project.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/Project.java
@@ -5,8 +5,25 @@ import com.google.api.client.util.Key;
 
 public class Project extends GenericJson {
 
+	@Key("Id")
+	private String id;
+
 	@Key("Name")
 	private String name;
+	
+	/**
+	 * @return the id
+	 */
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * @param id the id to set
+	 */
+	public void setId(String id) {
+		this.id = id;
+	}
 
 	/**
 	 * @return the name

--- a/src/main/java/it/infuse/jenkins/usemango/model/Response.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/Response.java
@@ -1,0 +1,58 @@
+package it.infuse.jenkins.usemango.model;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+
+import java.util.List;
+
+public class Response<T> extends GenericJson {
+    @Key("Items")
+    private List<T> items;
+    @Key("FullCount")
+    private int fullCount;
+    @Key("Offset")
+    private int offset;
+    @Key("Info")
+    private ResponseInfo info;
+
+    /**
+     * @return the items
+     */
+    public List<T> getItems() {
+        return items;
+    }
+
+    /**
+     * @return the fullCount
+     */
+    public int getFullCount() {
+        return fullCount;
+    }
+
+    /**
+     * @return the offset
+     */
+    public int getOffset() {
+        return offset;
+    }
+
+    /**
+     * @return the info
+     */
+    public ResponseInfo getInfo() {
+        return info;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof Response)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/src/main/java/it/infuse/jenkins/usemango/model/ResponseInfo.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/ResponseInfo.java
@@ -3,7 +3,7 @@ package it.infuse.jenkins.usemango.model;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Key;
 
-public class TestIndexInfo extends GenericJson {
+public class ResponseInfo extends GenericJson {
 
 	@Key("Next")
 	private String next;
@@ -65,7 +65,7 @@ public class TestIndexInfo extends GenericJson {
 
 	@Override
 	public boolean equals(Object o) {
-		if (!(o instanceof TestIndexInfo)) {
+		if (!(o instanceof ResponseInfo)) {
 			return false;
 		}
 		return super.equals(o);

--- a/src/main/java/it/infuse/jenkins/usemango/model/TestIndexResponse.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/TestIndexResponse.java
@@ -2,7 +2,7 @@ package it.infuse.jenkins.usemango.model;
 
 import java.util.List;
 
-public class TestIndexResponse extends Response<TestIndexItem> {
+public class TestIndexResponse extends PagedResponse<TestIndexItem> {
 
 	public List<TestIndexItem> getItems() {
 		return super.getItems();

--- a/src/main/java/it/infuse/jenkins/usemango/model/TestIndexResponse.java
+++ b/src/main/java/it/infuse/jenkins/usemango/model/TestIndexResponse.java
@@ -2,58 +2,10 @@ package it.infuse.jenkins.usemango.model;
 
 import java.util.List;
 
-import com.google.api.client.json.GenericJson;
-import com.google.api.client.util.Key;
+public class TestIndexResponse extends Response<TestIndexItem> {
 
-public class TestIndexResponse extends GenericJson {
-
-	@Key("Items")
-	private List<TestIndexItem> items;
-	@Key("FullCount")
-	private int fullCount;
-	@Key("Offset")
-	private int offset;
-	@Key("Info")
-	private TestIndexInfo info;
-
-	/**
-	 * @return the items
-	 */
 	public List<TestIndexItem> getItems() {
-		return items;
+		return super.getItems();
 	}
 
-	/**
-	 * @return the fullCount
-	 */
-	public int getFullCount() {
-		return fullCount;
-	}
-
-	/**
-	 * @return the offset
-	 */
-	public int getOffset() {
-		return offset;
-	}
-
-	/**
-	 * @return the info
-	 */
-	public TestIndexInfo getInfo() {
-		return info;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (!(o instanceof TestIndexResponse)) {
-			return false;
-		}
-		return super.equals(o);
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
 }

--- a/src/main/java/it/infuse/jenkins/usemango/util/APIUtils.java
+++ b/src/main/java/it/infuse/jenkins/usemango/util/APIUtils.java
@@ -21,9 +21,9 @@ public class APIUtils {
 	final static String ENDPOINT_PROJECTS 	= "/projects";
     final static String ENDPOINT_PROJECT 	= ENDPOINT_PROJECTS + "/%s";
     final static String ENDPOINT_TESTINDEX = ENDPOINT_PROJECT + "/testindex";
-	final static String ENDPOINT_USERS = "/users";
-	final static String ENDPOINT_ENVIRONMENTS = "/projects/%s/environments";
-	final static String ENDPOINT_DEFAULT_ENVIRONMENT = "/projects/%s/environments/default";
+    final static String ENDPOINT_USERS = "/users";
+    final static String ENDPOINT_ENVIRONMENTS = "/projects/%s/environments";
+    final static String ENDPOINT_DEFAULT_ENVIRONMENT = "/projects/%s/environments/default";
     final static String ENDPOINT_PROJECT_TAGS = ENDPOINT_PROJECT + "/testtags";
     final static String ENDPOINT_TEST_SCENARIOS = ENDPOINT_PROJECT + "/tests/%s/scenarios";
 
@@ -43,12 +43,12 @@ public class APIUtils {
 		return testAppURL;
 	}
 
-	public static Response<TestIndexItem> getTestIndex(TestIndexParams params, String idToken) throws IOException {
+	public static TestIndexResponse getTestIndex(TestIndexParams params, String idToken) throws IOException {
 		HttpRequestFactory requestFactory = HTTP_TRANSPORT.createRequestFactory(
 				(HttpRequest request) -> {request.setParser(new JsonObjectParser(JSON_FACTORY));
         });
 		Log.fine("Loading test index with filters: " + new Gson().toJson(params));
-		Response<TestIndexItem> response = null;
+		TestIndexResponse response = null;
 		while(true) { // handle pagination
 		    GenericUrl url = new GenericUrl(getTestServiceUrl());
 			url.setRawPath(API_VERSION + String.format(ENDPOINT_TESTINDEX, params.getProjectId()));
@@ -60,7 +60,7 @@ public class APIUtils {
 			HttpRequest request = requestFactory.buildGetRequest(url);
 			request.setHeaders(getHeadersForServer(idToken));
 			if(isAnotherPage(response)) {
-				Response<TestIndexItem> tmpResponse = request.execute().parseAs(TestIndexResponse.class);
+				TestIndexResponse tmpResponse = request.execute().parseAs(TestIndexResponse.class);
 				response.getItems().addAll(tmpResponse.getItems());
 				response.getInfo().setHasNext(tmpResponse.getInfo().isHasNext());
 				response.getInfo().setNext(tmpResponse.getInfo().getNext());
@@ -113,12 +113,12 @@ public class APIUtils {
 
 	@SuppressWarnings("unchecked")
 
-	public static Response<EnvironmentItem> getEnvironments(String idToken, String project) throws IOException {
+	public static EnvironmentResponse getEnvironments(String idToken, String project) throws IOException {
 		HttpRequestFactory requestFactory = HTTP_TRANSPORT.createRequestFactory(
 				(HttpRequest request) -> {request.setParser(new JsonObjectParser(JSON_FACTORY));
 				});
 
-		Response<EnvironmentItem> response = null;
+		EnvironmentResponse response = null;
 		while(true) { // handle pagination
 			GenericUrl url = new GenericUrl(getTestServiceUrl());
 
@@ -127,7 +127,7 @@ public class APIUtils {
 			HttpRequest request = requestFactory.buildGetRequest(url);
 			request.setHeaders(getHeadersForServer(idToken));
 			if(isAnotherPage(response)) {
-				Response<EnvironmentItem> tmpResponse = request.execute().parseAs(EnvironmentResponse.class);
+				EnvironmentResponse tmpResponse = request.execute().parseAs(EnvironmentResponse.class);
 				response.getItems().addAll(tmpResponse.getItems());
 				response.getInfo().setHasNext(tmpResponse.getInfo().isHasNext());
 				response.getInfo().setNext(tmpResponse.getInfo().getNext());
@@ -166,8 +166,8 @@ public class APIUtils {
 		return (ArrayList<Scenario>)response.parseAs(new TypeToken<ArrayList<Scenario>>(){}.getType());
 	}
 	
-	private static boolean isAnotherPage(Response response) {
-		return response != null && response.getInfo() != null && response.getInfo().isHasNext();
+	private static boolean isAnotherPage(PagedResponse pagedResponse) {
+		return pagedResponse != null && pagedResponse.getInfo() != null && pagedResponse.getInfo().isHasNext();
 	}
 
 	private static HttpHeaders getHeadersForServer(String idToken){

--- a/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/config.jelly
+++ b/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/config.jelly
@@ -25,6 +25,9 @@
     <f:entry field="assignedTo" title="Assigned to">
         <f:select/>
     </f:entry>
+    <f:entry field="environmentId" title="Environment">
+        <f:select checkMethod="post" />
+    </f:entry>
 	<f:validateButton title="Validate" progress="Validating..." 
-		method="validateSettings" with="projectId,tags,testName,testStatus,assignedTo"/>
+		method="validateSettings" with="projectId,tags,testName,testStatus,assignedTo,environmentId"/>
 </j:jelly>

--- a/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/config.jelly
+++ b/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/config.jelly
@@ -10,7 +10,7 @@
         <f:textbox checkMethod="post"/>
       </f:entry>
     </f:optionalBlock>
-    <f:entry field="projectId" title="Project ID">
+    <f:entry field="projectId" title="Project">
         <f:select checkMethod="post"/>
     </f:entry>
 	<f:entry field="tags" title="Tags">

--- a/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/help-environmentId.html
+++ b/src/main/resources/it/infuse/jenkins/usemango/UseMangoBuilder/help-environmentId.html
@@ -1,0 +1,3 @@
+<div>
+    Specify the environment to run the test(s) in. Default environment preselected.
+</div>

--- a/src/test/java/it/infuse/jenkins/usemango/UseMangoBuilderTest.java
+++ b/src/test/java/it/infuse/jenkins/usemango/UseMangoBuilderTest.java
@@ -19,13 +19,14 @@ public class UseMangoBuilderTest {
     final String testName = "TestFile";
     final String testStatus = "TestStatus";
     final String assignedTo = "TestAssignee";
+    final String environmentId = "Environment";
 
     @Ignore
     public void testConfigRoundtrip() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
-        project.getBuildersList().add(new UseMangoBuilder(useNodeLabel, nodeLabel, projectId, testName, tags, testStatus, assignedTo));
+        project.getBuildersList().add(new UseMangoBuilder(useNodeLabel, nodeLabel, projectId, testName, tags, testStatus, assignedTo, environmentId));
         project = jenkins.configRoundtrip(project);
-        jenkins.assertEqualDataBoundBeans(new UseMangoBuilder(useNodeLabel, nodeLabel, projectId, testName, tags, testStatus, assignedTo),
+        jenkins.assertEqualDataBoundBeans(new UseMangoBuilder(useNodeLabel, nodeLabel, projectId, testName, tags, testStatus, assignedTo, environmentId),
         		project.getBuildersList().get(0));
     }
 


### PR DESCRIPTION
## Added a new dropdown in the useMango step builder.

### UI changes
- The environment dropdown is populated based on the Project selected. 

- The default environment is preselected.
![image](https://github.com/infuse-consulting/usemango-runner-plugin/assets/52605935/029ca80b-e5af-423b-8e3b-c80fb87d2e68)

- Help text
![image](https://github.com/infuse-consulting/usemango-runner-plugin/assets/52605935/0ef4b5ae-7be1-42c4-a732-21c693bf7a6d)

Test runs with environment id arg
![image](https://github.com/infuse-consulting/usemango-runner-plugin/assets/52605935/407ddd08-d70b-4d7f-aaf7-fab351463c8f)


### Code changes
- Added a new EnvironmentItem class
- Integrated with existing response class for TestIndex items which also gets paginated response
- Added field to distinguish project id and project name [Make changes related to Rename of the Project](https://usemango.atlassian.net/browse/UMDEV-3494)