### PR TITLE
Bugfix UMDEV-6306 : Default dataset is not run when other datasets are present

### DIFF
--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
@@ -135,15 +135,12 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 				};
 				testIndexes.getItems().forEach((test) -> {
 					try {
+						queueTest.accept(test, null);
 						if (test.getHasScenarios()){
-							queueTest.accept(test, null);
 							List<Scenario> scenarios = getTestScenarios(this.projectId, test.getId());
 							scenarios.forEach((scenario) -> {
 								queueTest.accept(test, scenario);
 							});
-						}
-						else {
-							queueTest.accept(test, null);
 						}
 					} catch(Exception e) {
 						listener.error("Error executing test: "+test.getName());

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoBuilder.java
@@ -136,6 +136,7 @@ public class UseMangoBuilder extends Builder implements BuildStep {
 				testIndexes.getItems().forEach((test) -> {
 					try {
 						if (test.getHasScenarios()){
+							queueTest.accept(test, null);
 							List<Scenario> scenarios = getTestScenarios(this.projectId, test.getId());
 							scenarios.forEach((scenario) -> {
 								queueTest.accept(test, scenario);

--- a/src/main/java/it/infuse/jenkins/usemango/UseMangoTestResultsAction.java
+++ b/src/main/java/it/infuse/jenkins/usemango/UseMangoTestResultsAction.java
@@ -64,7 +64,8 @@ public class UseMangoTestResultsAction implements RunAction2 {
                 for (ExecutableTest exeScenario: testScenarios) {
                     if (!exeScenario.isPassed()) { testPassed = false; }
                     Scenario scenario = exeScenario.getScenario();
-                    TestResult result = new TestResult(scenario.getName(), exeScenario.isPassed(), getReportLink(exeScenario.getRunId()), null);
+                    String scenarioName = (scenario != null && scenario.getName() != null) ? scenario.getName() : "default";
+                    TestResult result = new TestResult(scenarioName, exeScenario.isPassed(), getReportLink(exeScenario.getRunId()), null);
                     scenarioResults.add(result);
                 }
                 this.tests.add(new TestResult(testScenarios.get(0).getName(), testPassed, null, scenarioResults));


### PR DESCRIPTION
Default dataset was not executing when other datasets were provided. This commit addresses the issue by ensuring that the Default dataset runs properly even when other datasets are present.